### PR TITLE
docs: add completion plan, security, privacy, and threat-model baselines

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,39 @@
+# PRIVACY.md
+
+## Assumptions
+- VinylFort processes user-uploaded images and text extracted from those images.
+- Deployment may serve UK/EU users and must align with UK GDPR/GDPR principles.
+
+## Scope
+Data minimization, retention, deletion, and transparency requirements.
+
+## Data categories
+- Account/contact data (if auth is enabled): email, profile identifiers.
+- Content data: uploaded images, OCR text, listing drafts.
+- Operational metadata: timestamps, request IDs, source provenance for pricing.
+
+## Lawful handling principles
+- Collect only data necessary for listing generation and diagnostics.
+- Separate operational logs from user content.
+- Avoid storing raw uploaded media longer than required.
+
+## Retention policy (baseline)
+- Uploaded images: default TTL 30 days (configurable by policy).
+- OCR text and generated drafts: retained until user deletion or account closure.
+- Request logs: 30–90 days, redacted for PII/secrets.
+- Pricing provenance records: retain for auditability with pseudonymized user linkage.
+
+## User rights workflow
+- Export: provide user-readable export of listing drafts and associated metadata.
+- Deletion: delete account data and purge linked content within defined SLA.
+- Rectification: allow edits/corrections to saved listing data.
+
+## Privacy by design requirements
+- Default private storage for uploads and drafts.
+- Role-restricted access for operational/admin tools.
+- Data processing inventory and DPIA maintained for major feature additions.
+
+## Third-party processors
+- Document each processor and data category shared.
+- Use DPAs where required.
+- Review non-API public data sources before automation; require explicit permission/licensing.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,52 @@
----
-title: VinylVault Pro 🎧
-colorFrom: purple
-colorTo: pink
-emoji: 🐳
-sdk: static
-pinned: false
-tags:
-  - deepsite-v3
----
+# VinylFort
 
-# Welcome to your new DeepSite project!
-This project was created with [DeepSite](https://huggingface.co/deepsite).
+## Assumptions
+- This repository is currently a static web application (`index.html`, `style.css`, `script.js`) used to generate record listing drafts.
+- The near-term goal is to make the project production-ready without rewriting the UI first.
+- Credentialed third-party integrations (Discogs, AI providers, marketplace APIs) should move server-side before launch.
+
+## Scope
+This repository now includes a concrete completion plan and security/compliance baseline documents for the next implementation phase:
+- Architecture and delivery roadmap.
+- Security controls and operational requirements.
+- Privacy and data-retention policy baseline.
+- STRIDE-oriented threat model.
+
+## How to run (current app)
+1. Serve the repository with any static file server.
+2. Open `index.html` in a browser.
+
+Examples:
+
+```bash
+python3 -m http.server 8080
+# then visit http://localhost:8080
+```
+
+## Current file tree (selected)
+
+```text
+.
+├── index.html
+├── style.css
+├── script.js
+├── components/
+├── SECURITY.md
+├── PRIVACY.md
+├── THREATMODEL.md
+└── docs/
+    └── COMPLETION_PLAN.md
+```
+
+## Commands to run
+
+```bash
+python3 -m http.server 8080
+node --check script.js
+```
+
+## Documentation added
+- `docs/COMPLETION_PLAN.md` — phased completion plan with priorities and acceptance criteria.
+- `SECURITY.md` — minimum security baseline and hardening checklist.
+- `PRIVACY.md` — UK GDPR-oriented data handling and retention policy.
+- `THREATMODEL.md` — STRIDE threat model and mitigations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# SECURITY.md
+
+## Assumptions
+- VinylFort will be deployed as a web app with server-side endpoints handling third-party API credentials.
+- User-uploaded images may contain sensitive personal data.
+
+## Scope
+Minimum security baseline for development, deployment, and operations.
+
+## Security baseline
+
+### 1) Secrets and credentials
+- No secrets in client code, localStorage, or committed files.
+- Store secrets in environment manager/Vault/KMS with rotation policy.
+- Use least-privilege tokens per integration (Discogs/eBay/AI).
+
+### 2) API and input hardening
+- Validate all API inputs at edge with schema validation (recommended: Zod).
+- Enforce timeout + retry-with-jitter + bounded concurrency for outbound HTTP.
+- Block SSRF-sensitive destinations (metadata/link-local/private ranges unless explicitly allow-listed).
+
+### 3) Authentication and authorization
+- Default-deny authorization model.
+- Short-lived access tokens and rotating refresh tokens where auth is introduced.
+- Mutating endpoints require idempotency keys.
+
+### 4) Browser and transport controls
+- Enforce HTTPS (TLS 1.2+, prefer 1.3).
+- Set strict response headers:
+  - `Content-Security-Policy`
+  - `X-Frame-Options: DENY`
+  - `X-Content-Type-Options: nosniff`
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - minimal `Permissions-Policy`
+
+### 5) Upload security
+- Enforce file type/size allow-list server-side.
+- Store uploads outside web root.
+- Add malware scanning for production uploads.
+
+### 6) Abuse prevention and reliability
+- Global and route-level rate limits.
+- Request and job queue caps; dead-letter handling for failures.
+- Structured logs with request ID; never log secrets or raw tokens.
+
+## Security testing requirements
+- SAST and dependency audit on CI.
+- Regression tests for each security defect.
+- No live network in tests; mock external APIs.
+
+## Incident response (minimum)
+- Maintain on-call contacts and escalation matrix.
+- Preserve timestamped audit logs.
+- Publish post-incident review with remediation actions.

--- a/THREATMODEL.md
+++ b/THREATMODEL.md
@@ -1,0 +1,72 @@
+# THREATMODEL.md
+
+## Assumptions
+- Architecture target: static front-end + serverless API broker + persistent storage.
+- Primary external dependencies: Discogs, AI providers, marketplace APIs.
+
+## Scope
+High-level STRIDE threat model for VinylFort’s target architecture.
+
+## Data flow (high-level)
+1. User uploads image and metadata from browser.
+2. Backend validates request, stores media, runs OCR/AI extraction.
+3. Backend queries metadata/pricing providers.
+4. Backend computes listing draft + pricing recommendation.
+5. User reviews/exports listing draft.
+
+## STRIDE summary
+
+### S — Spoofing
+- Risk: forged client requests or token replay.
+- Mitigations:
+  - signed/authenticated sessions,
+  - short-lived tokens,
+  - anti-replay controls and idempotency keys.
+
+### T — Tampering
+- Risk: manipulated pricing/provenance payloads or altered drafts.
+- Mitigations:
+  - server-side validation and canonicalization,
+  - integrity checks on stored artifacts,
+  - append-only provenance events.
+
+### R — Repudiation
+- Risk: no traceability of who changed listing/pricing decisions.
+- Mitigations:
+  - immutable audit events with request correlation IDs,
+  - timestamped actor attribution.
+
+### I — Information disclosure
+- Risk: leaked API keys, PII in logs, exposed uploaded images.
+- Mitigations:
+  - server-only secrets,
+  - log redaction,
+  - private object storage + signed URL expiry,
+  - strict CSP and security headers.
+
+### D — Denial of service
+- Risk: expensive OCR/AI endpoints abused at scale.
+- Mitigations:
+  - per-user/per-IP throttling,
+  - queue and concurrency caps,
+  - caching of repeated metadata requests,
+  - circuit-breakers and fallback behaviors.
+
+### E — Elevation of privilege
+- Risk: unauthorized admin actions or cross-tenant data access.
+- Mitigations:
+  - default-deny RBAC/ABAC,
+  - resource-scoped authorization checks,
+  - tenancy-aware query filters and tests.
+
+## Priority risk register
+1. Client-side secret exposure (critical).
+2. Unauthorized data access to uploads/drafts (high).
+3. Third-party API abuse and quota exhaustion (high).
+4. Inaccurate pricing output without provenance (medium).
+5. Incomplete deletion/retention controls (medium).
+
+## Validation checkpoints
+- Pre-release threat model review.
+- Security regression tests in CI.
+- Quarterly review of processors and data flows.

--- a/docs/COMPLETION_PLAN.md
+++ b/docs/COMPLETION_PLAN.md
@@ -1,0 +1,63 @@
+# VinylFort Completion Plan
+
+## Assumptions
+- Existing UI/UX remains in place during the first hardening phase.
+- Priority is secure deployment readiness, not visual redesign.
+- Non-API data sources are manual-import only until explicit licensing/permission exists.
+
+## Scope
+This plan covers the path from static prototype to production-ready architecture.
+
+## Phase 0 — Stabilize baseline (1 week)
+- Refactor duplicated logic in `script.js` into small modules.
+- Introduce linting + formatting + type-checking migration path (JS -> TS incrementally).
+- Add unit-test harness (Vitest) and first coverage on deterministic utility logic.
+- Add CI checks for lint + tests.
+
+### Exit criteria
+- Deterministic behavior for parsing/matching helpers covered by tests.
+- CI required on pull requests.
+
+## Phase 1 — Security and backend broker (1–2 weeks)
+- Add serverless/API layer for all credentialed calls:
+  - `/api/discogs/search`
+  - `/api/discogs/release/:id`
+  - `/api/ai/extract`
+  - `/api/price/estimate`
+- Remove all API secrets from browser storage/localStorage.
+- Add rate limiting, retry with backoff, timeout guards, and request correlation IDs.
+
+### Exit criteria
+- Front-end no longer sends credentialed requests directly to third parties.
+- All secrets are server-only environment variables.
+
+## Phase 2 — Metadata identity and pricing provenance (2–3 weeks)
+- Implement pressing matching with weighted signals:
+  - barcode / release-id / catalog number / label / text similarity.
+- Persist candidate rankings and rationale.
+- Implement provenance-aware pricing model:
+  - source tag, fetched_at, filters, currency normalization, outlier handling.
+
+### Exit criteria
+- Every suggested price includes source provenance and confidence band.
+
+## Phase 3 — Compliance and resilience (1–2 weeks)
+- Formalize data retention and deletion jobs.
+- Add abuse controls (per-IP/per-user limits, bounded queues).
+- Add audit logs that exclude secrets/PII.
+
+### Exit criteria
+- Published privacy policy and operator runbook.
+- Evidence of retention enforcement.
+
+## Phase 4 — Launch readiness (1 week)
+- End-to-end smoke tests (photo intake -> matching -> listing draft).
+- Error budget dashboards and alerts (RED metrics).
+- Production deployment with staged rollback plan.
+
+### Exit criteria
+- Release checklist passes on staging and production.
+
+## Non-goals (for now)
+- Automated scraping of sites without explicit API/permission.
+- Multi-region deployment and advanced ML model hosting.


### PR DESCRIPTION
### Motivation
- Provide a clear, actionable path from the current static prototype to a production-ready app with a server-side broker and provable pricing provenance. 
- Establish minimum security, privacy, and operational guardrails (secrets, uploads, rate limits, GDPR-aligned retention) so future work can be implemented safely. 
- Improve developer onboarding with a project-oriented `README` and a documented phased roadmap to reduce unblocker friction for follow-up engineering work. 

### Description
- Replace `README.md` with a project-focused overview that includes assumptions, a selected file tree, local run instructions, and quick validation commands. 
- Add `docs/COMPLETION_PLAN.md` containing a phased roadmap (stabilize → backend broker → provenance → compliance → launch). 
- Add security and governance docs: `SECURITY.md` (secrets, input hardening, headers, upload rules, abuse controls), `PRIVACY.md` (data categories, retention, user rights), and `THREATMODEL.md` (STRIDE analysis and risk register). 
- Change set is documentation-only and does not modify runtime application logic. 

### Testing
- Ran `node --check script.js` to validate the existing client script syntax, and the check completed successfully. 
- No additional automated test suites (unit/integration/E2E) were added or executed as part of this documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5f94c648833389e42e59d600d2ef)