### PR TITLE
chore: add base package.json with tooling scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vinylfort",
+  "version": "1.0.0",
+  "private": true,
+  "description": "VinylFort front-end application tooling",
+  "scripts": {
+    "lint": "eslint . --ext .js,.mjs,.cjs --max-warnings=0",
+    "typecheck": "echo \"No TypeScript sources configured yet\"",
+    "test": "echo \"No automated tests configured yet\"",
+    "format": "prettier --check ."
+  },
+  "devDependencies": {
+    "eslint": "^9.21.0",
+    "eslint-plugin-security": "^3.0.1",
+    "eslint-plugin-unicorn": "^57.0.0",
+    "prettier": "^3.5.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@10.5.2"
+}


### PR DESCRIPTION
### Motivation
- Bootstrap the repository with a minimal `package.json` to prepare for adding TypeScript and standard developer tooling and to enforce Node/pnpm engine constraints.

### Description
- Add `package.json` at the repo root containing project metadata, `engines` set to `node >=20`, `packageManager` set to `pnpm@10.5.2`, scripts `lint`, `typecheck`, `test`, and `format`, and initial devDependencies `eslint`, `eslint-plugin-security`, `eslint-plugin-unicorn`, and `prettier`.

### Testing
- Validated the file is well-formed JSON by running `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a612712d483338a04e9b389746b29)