### PR TITLE
fix(listing): initialize detectedPhotoTypes to fix quick preview

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,6 +143,7 @@ function updateAnalysisProgress(percent, stageText) {
 let uploadedPhotos = [];
 let hostedPhotoUrls = [];
 let photoObjectUrls = []; // Track object URLs for cleanup
+const detectedPhotoTypes = new Set(); // Track inferred shot types for quick preview and checklist rendering
 const dropZone = document.getElementById('dropZone');
 const photoInput = document.getElementById('photoInput');
 const photoGrid = document.getElementById('photoGrid');


### PR DESCRIPTION
### Motivation
- Resolve a ReferenceError where `detectedPhotoTypes` was referenced by multiple preview/upload/checklist code paths but never declared, which broke quick preview and listing creation flows.

### Description
- Add a module-level initialization `const detectedPhotoTypes = new Set();` in `script.js` so inferred shot types are tracked for preview generation and checklist rendering.

### Testing
- Ran `pnpm lint` and it passed successfully.
- Ran `pnpm typecheck && pnpm test` (project prints placeholder messages for these scripts) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a74b1b8348333b50e0c254f3e8f6f)