### PR TITLE
chore: add static preview script for local screenshot runs

### DIFF
--- a/components/deepseek-service.js
+++ b/components/deepseek-service.js
@@ -57,7 +57,7 @@ class DeepseekService {
         content: `You are a vinyl record identification expert specializing in pressing identification. Analyze record images and extract all visible information with special attention to first press vs reissue identification.
 
 CRITICAL - Pressing Identification Rules:
-1. DEADWAX/MATRIX ANALYSIS IS ESSENTIAL - Look for:
+1. DEADWAX/MATRIX ANALYSIS IS ESSENTIAL - Look for (capture Side A and Side B separately whenever possible):
    - Hand-etched vs machine-stamped matrix numbers (hand-etched often indicates early pressings)
    - Plant identifiers: "STERLING", "RL", "PORKY", "TML", "EMI", "CBS"
    - Mastering engineer initials or signatures
@@ -120,7 +120,7 @@ Be precise. Only include info you can clearly read. For pressing identification,
         content: [
           {
             type: 'text',
-            text: 'Analyze these record photos. Identify the artist, title, catalogue number, label, year, and CRITICALLY: examine the deadwax/matrix area and labels closely to determine if this is a first pressing, repress, or reissue. Report any matrix numbers, plant codes, or label variations you can see.'
+            text: 'Analyze these record photos. Identify the artist, title, catalogue number, label, year, and CRITICALLY: examine the deadwax/matrix area and labels closely to determine if this is a first pressing, repress, or reissue. Explicitly extract Matrix Side A and Matrix Side B runouts separately whenever visible, and report any plant codes or label variations you can see.'
           },
           ...base64Images.map(base64 => ({
             type: 'image_url',

--- a/components/enhanced-ocr-service.js
+++ b/components/enhanced-ocr-service.js
@@ -20,7 +20,7 @@ class EnhancedOCRService {
         content: `You are a vinyl record identification expert with advanced OCR capabilities specializing in pressing identification. Analyze record images and extract all visible information with special attention to first press vs reissue identification.
 
 CRITICAL - Pressing Identification Rules:
-1. DEADWAX/MATRIX ANALYSIS IS ESSENTIAL - Look for:
+1. DEADWAX/MATRIX ANALYSIS IS ESSENTIAL - Look for (capture Side A and Side B separately whenever possible):
    - Hand-etched vs machine-stamped matrix numbers (hand-etched often indicates early pressings)
    - Plant identifiers: "STERLING", "RL", "PORKY", "TML", "EMI", "CBS"
    - Mastering engineer initials or signatures
@@ -83,7 +83,7 @@ Be precise. Only include info you can clearly read. For pressing identification,
         content: [
           {
             type: 'text',
-            text: 'Analyze these record photos. Identify the artist, title, catalogue number, label, year, and CRITICALLY: examine the deadwax/matrix area and labels closely to determine if this is a first pressing, repress, or reissue. Report any matrix numbers, plant codes, or label variations you can see.'
+            text: 'Analyze these record photos. Identify the artist, title, catalogue number, label, year, and CRITICALLY: examine the deadwax/matrix area and labels closely to determine if this is a first pressing, repress, or reissue. Explicitly extract Matrix Side A and Matrix Side B runouts separately whenever visible, and report any plant codes or label variations you can see.'
           },
           ...base64Images.map(base64 => ({
             type: 'image_url',

--- a/components/ocr-service.js
+++ b/components/ocr-service.js
@@ -20,7 +20,7 @@ class OCRService {
         content: `You are a vinyl record identification expert specializing in pressing identification. Analyze record images and extract all visible information with special attention to first press vs reissue identification.
 
 CRITICAL - Pressing Identification Rules:
-1. DEADWAX/MATRIX ANALYSIS IS ESSENTIAL - Look for:
+1. DEADWAX/MATRIX ANALYSIS IS ESSENTIAL - Look for (capture Side A and Side B separately whenever possible):
    - Hand-etched vs machine-stamped matrix numbers (hand-etched often indicates early pressings)
    - Plant identifiers: "STERLING", "RL", "PORKY", "TML", "EMI", "CBS"
    - Mastering engineer initials or signatures
@@ -83,7 +83,7 @@ Be precise. Only include info you can clearly read. For pressing identification,
         content: [
           {
             type: 'text',
-            text: 'Analyze these record photos. Identify the artist, title, catalogue number, label, year, and CRITICALLY: examine the deadwax/matrix area and labels closely to determine if this is a first pressing, repress, or reissue. Report any matrix numbers, plant codes, or label variations you can see.'
+            text: 'Analyze these record photos. Identify the artist, title, catalogue number, label, year, and CRITICALLY: examine the deadwax/matrix area and labels closely to determine if this is a first pressing, repress, or reissue. Explicitly extract Matrix Side A and Matrix Side B runouts separately whenever visible, and report any plant codes or label variations you can see.'
           },
           ...base64Images.map(base64 => ({
             type: 'image_url',

--- a/index.html
+++ b/index.html
@@ -262,6 +262,23 @@
                                 </div>
                             </div>
 
+                            <div class="grid grid-cols-2 gap-3">
+                                <div>
+                                    <label for="matrixSideAInput" class="block text-sm text-gray-400 mb-1 font-medium">Matrix Side A</label>
+                                    <input type="text" id="matrixSideAInput" placeholder="e.g. SHVL 804 A-2" 
+                                        class="w-full px-3 py-2 bg-surface border border-gray-700 rounded-lg focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 text-sm transition-all"
+                                        aria-describedby="matrix-a-help">
+                                    <div id="matrix-a-help" class="sr-only">Enter the exact matrix or runout inscription from side A</div>
+                                </div>
+                                <div>
+                                    <label for="matrixSideBInput" class="block text-sm text-gray-400 mb-1 font-medium">Matrix Side B</label>
+                                    <input type="text" id="matrixSideBInput" placeholder="e.g. SHVL 804 B-2" 
+                                        class="w-full px-3 py-2 bg-surface border border-gray-700 rounded-lg focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 text-sm transition-all"
+                                        aria-describedby="matrix-b-help">
+                                    <div id="matrix-b-help" class="sr-only">Enter the exact matrix or runout inscription from side B</div>
+                                </div>
+                            </div>
+
                             <div>
                                 <label for="costInput" class="block text-sm text-gray-400 mb-1 font-medium">Purchase Price (£)</label>
                                 <input type="number" id="costInput" placeholder="0.00" step="0.01" min="0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint . --ext .js,.mjs,.cjs --max-warnings=0",
     "typecheck": "echo \"No TypeScript sources configured yet\"",
     "test": "echo \"No automated tests configured yet\"",
-    "format": "prettier --check ."
+    "format": "prettier --check .",
+    "preview:static": "python3 -m http.server 4173 --directory ."
   },
   "devDependencies": {
     "eslint-plugin-security": "file:tools/eslint-plugin-security"

--- a/script.js
+++ b/script.js
@@ -611,7 +611,14 @@ populateFieldsFromOCR(result);
         // Try to fetch additional data from Discogs with pressing-aware matching
         if (result.artist && result.title && window.discogsService) {
             try {
-                const match = await window.discogsService.matchReleaseFromOcr(result);
+                const quickMatrixA = document.getElementById('matrixSideAInput')?.value?.trim();
+                const quickMatrixB = document.getElementById('matrixSideBInput')?.value?.trim();
+                const mergedOcrData = {
+                    ...result,
+                    matrixRunoutA: result.matrixRunoutA || quickMatrixA || null,
+                    matrixRunoutB: result.matrixRunoutB || quickMatrixB || null
+                };
+                const match = await window.discogsService.matchReleaseFromOcr(mergedOcrData);
                 if (match?.release) {
                     populateFieldsFromDiscogs(match.release);
                     updateDiscogsMatchPanel(match);
@@ -697,7 +704,9 @@ function populateFieldsFromOCR(data) {
         'artistInput': data.artist,
         'titleInput': data.title,
         'catInput': data.catalogueNumber,
-        'yearInput': data.year
+        'yearInput': data.year,
+        'matrixSideAInput': data.matrixRunoutA,
+        'matrixSideBInput': data.matrixRunoutB
     };
 
     let populatedCount = 0;
@@ -754,7 +763,7 @@ function populateFieldsFromOCR(data) {
 }
 // Track user modifications to fields
 document.addEventListener('DOMContentLoaded', () => {
-    ['artistInput', 'titleInput', 'catInput', 'yearInput'].forEach(id => {
+    ['artistInput', 'titleInput', 'catInput', 'yearInput', 'matrixSideAInput', 'matrixSideBInput'].forEach(id => {
         const field = document.getElementById(id);
         if (field) {
             field.addEventListener('input', () => {
@@ -1665,7 +1674,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -2661,7 +2670,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -3473,7 +3482,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -4369,7 +4378,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -5244,7 +5253,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -6240,7 +6249,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -7144,7 +7153,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';
@@ -8040,7 +8049,7 @@ async function generateListingWithAI() {
         },
         {
             role: 'user',
-            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
+            content: `Generate an eBay listing for: ${artist} - ${title}${catNo ? ` (Catalog: ${catNo})` : ''}${year ? ` (${year})` : ''}${document.getElementById('matrixSideAInput')?.value?.trim() ? ` (Matrix A: ${document.getElementById('matrixSideAInput').value.trim()})` : ''}${document.getElementById('matrixSideBInput')?.value?.trim() ? ` (Matrix B: ${document.getElementById('matrixSideBInput').value.trim()})` : ''}. Include optimized title options, professional HTML description, condition guidance, price estimate in GBP, and relevant tags.`
         }
     ];
     const provider = localStorage.getItem('ai_provider') || 'openai';


### PR DESCRIPTION
### Motivation
- Provide a stable, repeatable local static server command so Playwright/UI screenshot runs can reliably reach `index.html` (workaround for prior `ERR_EMPTY_RESPONSE`).

### Description
- Added a `preview:static` npm script to `package.json` with `python3 -m http.server 4173 --directory .` and committed the change, then re-ran validation and captured the UI screenshot for the Quick Details matrix fields.

### Testing
- Ran `pnpm lint && pnpm typecheck && pnpm test` which completed successfully; started the server with `pnpm preview:static` (aka `python3 -m http.server 4173 --directory .`) and executed the Playwright screenshot run which succeeded and produced the artifact `browser:/tmp/codex_browser_invocations/17ca54a596aca094/artifacts/artifacts/quick-details-matrix-fixed.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a78d190608333a182fcdbb0e709a1)